### PR TITLE
Remove AutoValue - Fix issue #45

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'android-apt'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion '23.0.3'
+  compileSdkVersion 25
+  buildToolsVersion '25.0.1'
 
   defaultConfig {
     applicationId "com.solera.defragsample"
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 25
     versionCode 1
     versionName "1.0"
   }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'

--- a/defrag/build.gradle
+++ b/defrag/build.gradle
@@ -8,12 +8,12 @@ version = '1.1.1'
 
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 2
         versionName "${version}"
     }
@@ -31,12 +31,6 @@ dependencies {
 
     compile "com.android.support:appcompat-v7:${android_support_lib_version}"
     compile "com.android.support:support-annotations:${android_support_lib_version}"
-
-    // Auto value
-    provided "com.google.auto.value:auto-value:${auto_value_lib_version}"
-    apt "com.google.auto.value:auto-value:${auto_value_lib_version}"
-    apt "com.ryanharter.auto.value:auto-value-parcel:0.2.5"
-    compile "com.ryanharter.auto.value:auto-value-parcel-adapter:0.2.5"
 }
 
 def siteUrl = 'https://github.com/R3PI/Defrag'

--- a/defrag/src/main/java/com/solera/defrag/TraversalAnimation.java
+++ b/defrag/src/main/java/com/solera/defrag/TraversalAnimation.java
@@ -3,23 +3,56 @@ package com.solera.defrag;
 import android.animation.Animator;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
-import com.google.auto.value.AutoValue;
 import java.lang.annotation.Retention;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
-@AutoValue public abstract class TraversalAnimation {
+public class TraversalAnimation {
 	public static final int ABOVE = 0;
 	public static final int BELOW = 1;
+	private final Animator mAnimator;
+	private final int mDrawOrder;
 
 	@NonNull public static TraversalAnimation newInstance(@NonNull Animator animator,
 			@AnimateInDrawOrder int drawOrder) {
-		return new AutoValue_TraversalAnimation(animator, drawOrder);
+		return new TraversalAnimation(animator, drawOrder);
 	}
 
-	@NonNull abstract Animator animator();
+	private TraversalAnimation(@NonNull Animator animator, @AnimateInDrawOrder int drawOrder) {
+		mAnimator = animator;
+		mDrawOrder = drawOrder;
+	}
 
-	@AnimateInDrawOrder abstract int drawOrder();
+	@NonNull Animator animator() {
+		return mAnimator;
+	}
+
+	@AnimateInDrawOrder int drawOrder() {
+		return mDrawOrder;
+	}
+
+	@Override public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		TraversalAnimation that = (TraversalAnimation) o;
+
+		if (mDrawOrder != that.mDrawOrder) return false;
+		return mAnimator != null ? mAnimator.equals(that.mAnimator) : that.mAnimator == null;
+	}
+
+	@Override public int hashCode() {
+		int result = mAnimator != null ? mAnimator.hashCode() : 0;
+		result = 31 * result + mDrawOrder;
+		return result;
+	}
+
+	@Override public String toString() {
+		return "TraversalAnimation{" +
+				"mAnimator=" + mAnimator +
+				", mDrawOrder=" + mDrawOrder +
+				'}';
+	}
 
 	@Retention(SOURCE) @IntDef({ ABOVE, BELOW }) public @interface AnimateInDrawOrder {
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 # Google libs
-android_support_lib_version = 23.4.0
+android_support_lib_version = 25.1.0
 
 #Auto value
 auto_value_lib_version = 1.3


### PR DESCRIPTION
This PR fixes #45 by **removing autovalue** - the crash is due to auto-value-parcel.

AutoValue is a great tool, but I question if **in this project** it causing more issues then it is solving. 

Changes:
* Remove AutoValue and implemented our own Parcelable implementation to fix app crashes in onRestoreSavedState.
* Update Android support library and SDK to latest versions.